### PR TITLE
Include LICENSE file into the sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
Congratulations on the new plugin! 😁 

This PR includes the `LICENSE` file into the `sdist`.