### PR TITLE
Enable displaying multiple fault hotspots

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,13 @@ pip install fault-localization
 With `fault-localization` installed, running
 
 ```bash
-pytest --localize {dir} [pytest args]
+pytest --localize {dir} [--n-hotspots {n}] [pytest args ...]
 ```
 
 will highlight suspicious lines encountered within `dir` while running the test configuration specified.
+`--n-hotspots` can optionally be provided to show the top `n` most suspicious lines (only one line, with surrounding context,
+is shown by default).
+
 If you suspect multiple sources of failure, or if there are multiple tests within your suite that 
 exercise the area of code you're interested in, using [pytest's `-k` flag](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests) is useful for running 
 fault localization on only a subset of your suite.

--- a/fault_localization/display.py
+++ b/fault_localization/display.py
@@ -67,7 +67,7 @@ def generate_output(line_scores, line_context=LINE_CONTEXT, n_lines=1):
             for line in try_get_line(line_no)
         )
 
-        out_buffer_key = '\u001b[1m{}\u001b[0m'.format(os.path.relpath(fname, os.getcwd()))
+        out_buffer_key = '\x1b[1m{}\x1b[0m'.format(os.path.relpath(fname, os.getcwd()))
         for line in output_lines:
             out_buffer[out_buffer_key].add(line)
 

--- a/fault_localization/display.py
+++ b/fault_localization/display.py
@@ -2,7 +2,7 @@
 
 import os
 import collections
-
+from operator import attrgetter
 
 LINE_CONTEXT = 5
 
@@ -31,49 +31,62 @@ def rgb_to_hex(*channels):
     return r * 36 + g * 6 + b + 16
 
 
-def generate_output(line_scores, line_context=LINE_CONTEXT):
+def generate_output(line_scores, line_context=LINE_CONTEXT, n_lines=1):
     """Given line scores, create final localization output."""
-    try:
-        fname, line_no = max(line_scores, key=line_scores.get)
-    except ValueError:
+    ranked_lines = sorted(line_scores, key=line_scores.get, reverse=True)
+    if not ranked_lines:
         yield "No lines from specified directory captured during test suite execution."
         return
 
-    max_score = line_scores[fname, line_no]
+    max_score = line_scores[ranked_lines[0]]
     min_score = min(line_scores.values())
 
-    with open(fname, 'r') as f:
-        file_contents = f.read().splitlines()
+    out_buffer = collections.defaultdict(set)
 
-    def try_get_line(line_no):
-        try:
-            yield file_contents[line_no]
-        except IndexError:
-            return
+    for _, (fname, line_no) in zip(range(n_lines), ranked_lines):
+        with open(fname, 'r') as f:
+            file_contents = f.read().splitlines()
 
-    output_lines = (
-        OutputLine(
-            num=line_no + 1,
-            content=line,
-            score=round(line_scores.get((fname, line_no), 0), 2)
+        def try_get_line(line_no):
+            try:
+                yield file_contents[line_no]
+            except IndexError:
+                return
+
+        output_lines = (
+            OutputLine(
+                num=line_no + 1,
+                content=line,
+                score=round(line_scores.get((fname, line_no), 0), 2)
+            )
+            for line_no in range(
+                line_no - line_context,
+                line_no + line_context + 1
+            )
+            if line_no >= 0
+            for line in try_get_line(line_no)
         )
-        for line_no in range(
-            line_no - line_context,
-            line_no + line_context + 1
-        )
-        if line_no >= 0
-        for line in try_get_line(line_no)
+
+        out_buffer_key = '\u001b[1m{}\u001b[0m'.format(os.path.relpath(fname, os.getcwd()))
+        for line in output_lines:
+            out_buffer[out_buffer_key].add(line)
+
+    out_buffer_sequence = sorted(
+        out_buffer.items(),
+        key=lambda k_v: max(k_v[1], key=attrgetter('score')),
+        reverse=True
     )
-
-    yield '\u001b[1m{}\u001b[0m'.format(os.path.relpath(fname, os.getcwd()))
-    for line in output_lines:
-        # todo: right-justify the numeric score value (rather than tab)
-        yield '{line.num}\t\x1b[48;5;{ansi_tag}m{line.content}\033[0m\t{line.score}'.format(
-            line=line,
-            ansi_tag=rgb_to_hex(
-                int(
-                    (line.score - min_score) / (max_score - min_score) * 255
-                ), 0, 0
-            )  # TODO - want to actually represent this in HSV space and go from neutral green/orange to red - see also http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#background-colors
-            # TODO - can we use RGB for background color rather than hex?
-        )
+    for header, lines in out_buffer_sequence:
+        yield header
+        for line in sorted(lines, key=attrgetter('num')):
+            # todo: right-justify the numeric score value (rather than tab)
+            yield '{line.num}\t\x1b[48;5;{ansi_tag}m{line.content}\033[0m\t{line.score}'.format(
+                line=line,
+                ansi_tag=rgb_to_hex(
+                    int(
+                        (line.score - min_score) / (max_score - min_score) * 255
+                    ), 0, 0
+                )
+                # TODO - want to actually represent this in HSV space and go from neutral green/orange to red - see also http://www.lihaoyi.com/post/BuildyourownCommandLinewithANSIescapecodes.html#background-colors
+                # TODO - can we use RGB for background color rather than hex?
+            )

--- a/fault_localization/plugin.py
+++ b/fault_localization/plugin.py
@@ -17,14 +17,14 @@ N_LINES = 1
 def pytest_addoption(parser):
     group = parser.getgroup('fault-localization', 'fault localization')
     group.addoption('--localize', help="directory in which to localize faults")
-    group.addoption('--n-top-lines', type=int, default=1, help="number of top-ranking lines to display")
+    group.addoption('--n-hotspots', type=int, default=1, help="number of top-ranking lines to display")
 
 
 def pytest_configure(config):
     global LOCALIZATION_DIR
     global N_LINES
     LOCALIZATION_DIR = config.getoption('--localize')
-    N_LINES = config.getoption('--n-top-lines')
+    N_LINES = config.getoption('--n-hotspots')
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/fault_localization/plugin.py
+++ b/fault_localization/plugin.py
@@ -11,16 +11,20 @@ from fault_localization.display import generate_output
 
 
 LOCALIZATION_DIR = None
+N_LINES = 1
 
 
 def pytest_addoption(parser):
     group = parser.getgroup('fault-localization', 'fault localization')
     group.addoption('--localize', help="directory in which to localize faults")
+    group.addoption('--n-top-lines', type=int, default=1, help="number of top-ranking lines to display")
 
 
 def pytest_configure(config):
     global LOCALIZATION_DIR
+    global N_LINES
     LOCALIZATION_DIR = config.getoption('--localize')
+    N_LINES = config.getoption('--n-top-lines')
 
 
 @pytest.hookimpl(hookwrapper=True)
@@ -55,5 +59,5 @@ def pytest_terminal_summary(terminalreporter):
         for (path, line), score in calc_scores().items()
         if path.startswith(abs_localization_dir)
     }
-    for line in generate_output(line_scores):
+    for line in generate_output(line_scores, n_lines=N_LINES):
         terminalreporter.write_line(line)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='fault-localization',
     packages=['fault_localization'],
     platforms='any',
-    version='0.1.5',
+    version='0.1.6',
     description='A fault localization tool for Python\'s pytest testing framework.',
     author='H. Chase Stevens',
     author_email='chase@chasestevens.com',


### PR DESCRIPTION
Adds `--n-hotspots` parameter to allow visualizing top `n` highest-scoring source lines.