### PR TITLE
All the suspiciousness scores are off by one.

### DIFF
--- a/fault_localization/display.py
+++ b/fault_localization/display.py
@@ -49,7 +49,7 @@ def generate_output(line_scores, line_context=LINE_CONTEXT, n_lines=1):
 
         def try_get_line(line_no):
             try:
-                yield file_contents[line_no]
+                yield file_contents[line_no - 1]
             except IndexError:
                 return
 


### PR DESCRIPTION
It seems like the suspiciousness scores are off by one. I used the following code example:
```python
def mid(x, y, z):
    m = z
    if y < z:
        if x < y:
            m = y
        elif x < z:
            m = y
    else:
        if x > y:
            m = y
        elif x > z:
            m = x
    
    return m
```

with 6 different inputs:
x, y, z
3, 3, 5
1, 2, 3
3, 2, 1
5, 5, 5
5, 3, 4
2, 1, 3

The output should respectively be: 3, 2, 2, 5, 4, 2. However, only the last test case will fail.
As a result, it should give the following output:
<img width="296" alt="correct" src="https://user-images.githubusercontent.com/5912953/63489938-4b458180-c468-11e9-81fb-70ad061a6014.png">

However, it outputs the following
<img width="291" alt="incorrect" src="https://user-images.githubusercontent.com/5912953/63489939-4bde1800-c468-11e9-86cf-37dafb53d1ec.png">

I think it has to do with the line numbering, and the patch should solve it. ([here](https://github.com/kajdreef/fault-localization-demo) a small demo project of the code to show the fix)